### PR TITLE
added container-update function

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -140,7 +140,38 @@ $lxd->containers->remove('container-name');
 
 #### Update container
 
-> TODO
+Replace containers configuration.<br />
+To avoid lost of configuration first of all current config can be read, changed and then set again.
+```
+<?php
+// Set container ephemeral (delete when stopped)
+$container = $lxd->containers->show('test');
+$container->ephemeral = true;
+$lxd->containers->replace('container-name', $container);
+```
+
+Restore a snapshot
+```
+<?php
+$lxd->containers->replace('container-name', ['restore' => 'snapshot-name'] );
+```
+
+Update containers configuration.<br />Example: set limit of cpu cores to 4 and rootfs size to 5GB
+
+```
+<?php
+$newconfig = [
+    'config' => [
+        'limits.cpu' => 4
+    ],
+    'devices' => [
+        'rootfs' => [
+            'size' => '5GB'
+        ]
+    ]
+];
+$lxd->containers->update('container-name', $container);
+```
 
 #### Change state
 
@@ -181,7 +212,7 @@ Unfreeze container:
 ```
 <?php
 
-$lxd->containers->start('container-name');
+$lxd->containers->unfreeze('container-name');
 ```
 
 #### Execute a command in a container

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,5 +31,5 @@ Wait for an operation to finish:
 ```
 <?php
 
-$lxd->operation->wait($uuid, $timeout);
+$lxd->operations->wait($uuid, $timeout);
 ```

--- a/src/Endpoint/Containers.php
+++ b/src/Endpoint/Containers.php
@@ -254,7 +254,7 @@ class Containers extends AbstructEndpoint
         if (!empty($options['source'])) {
             $opts = $this->getOptions($name, $options);
             $opts['source'] = $source;
-        } elseif ($options['empty']) {
+        } elseif (isset($options['empty']) && $options['empty']) {
             $opts = $this->getEmptyOptions($name, $options);
         } elseif (!empty($options['server'])) {
             $opts = $this->getRemoteImageOptions($name, $source, $options);
@@ -372,7 +372,7 @@ class Containers extends AbstructEndpoint
      * Example: Change container to be ephemeral (i.e. it will be deleted when stopped)
      *  $container = $lxd->containers->show('test');
      *  $container->ephemeral = true;
-     *  $lxd->containers->update('test', $container);
+     *  $lxd->containers->replace('test', $container);
      *
      * @param string $name Name of container
      * @param object $container Container to update
@@ -382,6 +382,38 @@ class Containers extends AbstructEndpoint
     public function replace($name, $container, $wait = false)
     {
         $response = $this->put($this->getEndpoint().$name, $container);
+
+        if ($wait) {
+            $response = $this->client->operations->wait($response['id']);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Update the configuration of a container
+     *
+     * Example: Change containers cpu-limit and rootfs size
+     *  $newconfig = [
+     *      'config' => [
+     *          'limits.cpu' => 4
+     *      ],
+     *      'devices' => [
+     *          'rootfs' => [
+     *              'size' => '5GB'
+     *          ]
+     *      ]
+     *  ];
+     *  $lxd->containers->update('test', $newconfig);
+     *
+     * @param string $name Name of container
+     * @param array $config Options to create the container
+     * @param bool $wait Wait for operation to finish
+     * @return object
+     */
+    public function update($name, $config, $wait = false)
+    {
+        $response = $this->patch($this->getEndpoint().$name, $config);
 
         if ($wait) {
             $response = $this->client->operations->wait($response['id']);


### PR DESCRIPTION
Added containers update-function (same as already existing replace function but patch instead of put) - Issue #10 
Added Documentation for update and replace function. Replace function can also be used to restore a snapshot (see Lxd-Api-Documentation for that: https://github.com/lxc/lxd/blob/master/doc/rest-api.md#user-content-put-etag-supported-2 )
Maybe in php-lxd this should be better placed in Snapshot class? could also be done like that:
$lxd->containers->snapshots->restore('container-name', 'snapshot-name');
but that would only be an alternative since the official API uses the put-method on containers endpoint

Minor things: added isset check when creating containers (because of PHP Notice) - Issue #9 

Additional: corrected some typos in current docs: Issue #11 

