### PR TITLE
execute with wait results in exception

### DIFF
--- a/src/Endpoint/Containers.php
+++ b/src/Endpoint/Containers.php
@@ -494,20 +494,21 @@ class Containers extends AbstructEndpoint
         if ($wait) {
             $response = $this->client->operations->wait($response['id']);
 
-            $logs = [];
-            $output = $response['metadata']['output'];
-            $return = $response['metadata']['return'];
-            unset($response);
+            if ($record === true) {
+                $output = $response['metadata']['output'];
+                $return = $response['metadata']['return'];
+                unset($response);
 
-            foreach ($output as $log) {
-                $response['output'][] = str_replace(
-                    '/'.$this->client->getApiVersion().'/containers/'.$name.'/logs/',
-                    '',
-                    $log
-                );
+                foreach ($output as $log) {
+                    $response['output'][] = str_replace(
+                        '/'.$this->client->getApiVersion().'/containers/'.$name.'/logs/',
+                        '',
+                        $log
+                    );
+                }
+
+                $response['return'] = $return;
             }
-
-            $response['return'] = $return;
         }
 
         return $response;

--- a/src/Endpoint/Containers.php
+++ b/src/Endpoint/Containers.php
@@ -492,12 +492,12 @@ class Containers extends AbstructEndpoint
         $response = $this->post($this->getEndpoint().$name.'/exec', $opts);
 
         if ($wait) {
-            $response = $this->client->operations->wait($response['id']);
+            $waitresponse = $this->client->operations->wait($response['id']);
 
             if ($record === true) {
-                $output = $response['metadata']['output'];
-                $return = $response['metadata']['return'];
-                unset($response);
+                $output = $waitresponse['metadata']['output'];
+                $return = $waitresponse['metadata']['return'];
+                $response = [];
 
                 foreach ($output as $log) {
                     $response['output'][] = str_replace(


### PR DESCRIPTION

$response['metadata']['output'] and $response['metadata']['return'] only contains values if "record-output" is set. But wait could also be used without record-output and then this results in an "exception 'ErrorException' with message 'Undefined index: output' in ..."

 fixed now - it record-output is not set, return same as if wait isn't set