### PR TITLE
Fix error if no output available

### DIFF
--- a/src/Endpoint/Containers.php
+++ b/src/Endpoint/Containers.php
@@ -495,7 +495,7 @@ class Containers extends AbstructEndpoint
             $waitresponse = $this->client->operations->wait($response['id']);
 
             if ($record === true) {
-                $output = $waitresponse['metadata']['output'];
+                $output = isset($waitresponse['metadata']['output']) ? $waitresponse['metadata']['output'] : [];
                 $return = $waitresponse['metadata']['return'];
                 $response = [];
 


### PR DESCRIPTION
In current LxD-Versions it seems like output isn't set always. e.g. if you only call a command like chmod, and additionally use the "wait" param, the script crashes because $waitresponse['metadata']['output'] isn't set.