### PR TITLE
Fixed problem with new installations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "psr/http-message": "^1.0",
         "php-http/httplug": "^1.0",
         "php-http/discovery": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/client-common": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
         "mockery/mockery": "^0.9.5",
-        "php-http/guzzle6-adapter": "^1.0",
         "guzzlehttp/psr7": "^1.2",
         "php-http/mock-client": "^0.3",
         "squizlabs/php_codesniffer": "^2.6"


### PR DESCRIPTION
Fresh installation throws:
  Problem 1
    - Installation request for opensaucesystems/lxd ^0.9.1 -> satisfiable by opensaucesystems/lxd[v0.9.1].
    - opensaucesystems/lxd v0.9.1 requires php-http/client-implementation ^1.0 -> no matching package found.

since php-http/client-implementation is a virtual package it needs an concrete client implementation before it can be added.  php-http/guzzle6-adapter fixes that requirement.